### PR TITLE
Add support for linux providing replacement for *.bat files and adding cslreferences environment to pandoc latex template

### DIFF
--- a/fig/pdf2png.py
+++ b/fig/pdf2png.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+'''
+Convert .pdf to .png files automatically
+from batch script:
+@echo off
+echo Turning .pdf to .png
+echo ""
+for %%f in (*.pdf) do (
+    echo   %%~nf
+    mutool.exe draw -o "%%~nf.png" -w 600 "%%~nf.pdf"
+)
+echo ""
+pause
+'''
+import os
+import glob
+import shlex
+import subprocess
+
+
+if __name__ == '__main__':
+    print("converting all *.pdf files to png")
+    
+    for f in glob.iglob('*.pdf'):
+        name, ext = os.path.splitext(f)
+        cmd = f'mutool draw -o "{name}.png" -w 600 "{name}.pdf"'
+        subprocess.run(shlex.split(cmd))
+
+    print("done!")

--- a/plan/Gant2html.py
+++ b/plan/Gant2html.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+'''
+Create Gantt diagrams.
+
+from batch script:
+@echo off
+@echo pandoc Gantt.md -o Gantt.html
+pandoc -s -t html5 Gantt.md --template templates/gantt-template.html -H templates/mermaid.min.js.html -o Gantt.html
+@echo sed fine-tuning...
+sed -i -- 's/.code.gantt/gantt/' Gantt.html
+sed -i -- 's/..code.\(..pre.\)/\1/' Gantt.html
+@echo.
+pause
+'''
+import shlex
+import subprocess
+
+if __name__ == '__main__':
+    print("pandoc Gantt.md -o Gantt.html")
+    cmd = (
+        'pandoc -s -t html5 Gantt.md'
+        ' --template templates/gantt-template.html'
+        ' --metadata title="Gant"'
+        ' -H templates/mermaid.min.js.html -o Gantt.html'
+    )
+    subprocess.run(shlex.split(cmd))
+
+    print("sed fine-tuning...")
+    cmd = 'sed -i -- \'s/.code.gantt/gantt/\' Gantt.html'
+    subprocess.run(shlex.split(cmd))
+    cmd = 'sed -i -- \'s/..code.\(..pre.\)/\1/\' Gantt.html'
+    subprocess.run(shlex.split(cmd))
+
+    print("done!")

--- a/plan/meetings/protocol2beamer.py
+++ b/plan/meetings/protocol2beamer.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+'''
+Create presentation
+
+from batch script:
+@echo off
+
+@echo "cat *protocol.md > summary.md"
+cat *protocol.md > summary.md
+
+@echo "pandoc summary.md -t beamer -o summary.pdf"
+pandoc summary.md  -t beamer --slide-level=2 -V theme:Singapore -o summary.pdf
+
+@echo "rm summary.md"
+rm summary.md
+pause
+'''
+import glob
+import shlex
+import subprocess
+
+if __name__ == '__main__':
+
+    print("cat *protocol.md > summary.md")
+    files = ' '.join(glob.glob('*protocol.md')
+    cmd = f'cat {files}'
+    with open('summary.md', "w") as f:
+        subprocess.run(shlex.split(cmd), stdout=f)
+    
+    print("pandoc summary.md -t beamer -o summary.pdf")
+    cmd = 'pandoc summary.md -t beamer --slide-level=2 -V theme:Singapore -o summary.pdf'
+    subprocess.run(shlex.split(cmd))
+
+    print("rm summary.md")
+    cmd = 'rm summary.md'
+    subprocess.run(shlex.split(cmd))

--- a/release/diff.py
+++ b/release/diff.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+'''
+Generates a diff
+
+from batch script:
+@echo off
+REM set folder names of released versions (. means the current (i.e. release) folder)
+set OLD=version20161209-145947
+set NEW=.
+
+REM use command line arguments, eg. diff.bat file1.tex file2.tex
+REM latexdiff %~1 %~2 > diff.tex
+
+REM or use filenames like the current .tex file in release/
+for %%i in (*.*) do if "%%~xi"==".tex" ( set NAME=%%~nxi )
+latexdiff %OLD%/%NAME% %NEW%/%NAME% > diff.tex
+
+REM compile diff.tex
+pdflatex diff.tex
+bibtex diff 
+pdflatex diff.tex
+pdflatex diff.tex
+
+REM remove auxillary files
+rm diff.out
+rm diff.aux
+rm diff.bbl
+rm diff.blg
+rm diff.log
+rm diff.tex
+
+echo Woohoo! I have successfully generated the file diff.pdf 
+pause
+'''
+import os
+import glob
+import shlex
+import subprocess
+from datetime import datetime
+
+
+if __name__ == '__main__':
+    # JF TODO: improve this later, take from command line argument
+    old_folder = 'version20161209-145947'
+    new_folder = '.'
+    diff_name = 'diff'
+
+    diff = diff_name + '.tex'
+
+    # get filename from extension
+    for f in glob.iglob('*.*'):
+        name, ext = os.path.splitext(f)
+        if ext == '.tex':
+            filename = f
+  
+    # run latexdiff on tex file
+    new = os.path.join(new_folder, filename)
+    old = os.path.join(old_folder, filename)
+    cmd = f'latexdiff {old} {new}'
+    with open(diff, "w") as f:
+        subprocess.run(shlex.split(cmd), stdout=f)
+
+    # compile to generate pdf showing diff
+    cmds = ['pdflatex', 'bibtex', 'pdflatex', 'pdflatex']
+    for cmd in cmds:
+        _cmd = f'{cmd} {diff}'
+        subprocess.run(shlex.split(_cmd))
+
+    # delete auxiliary files
+    auxs = ['.out', '.aux', '.bbl', '.blg', '.log', '.tex']
+    aux_files = ' '.join([f'{diff_name}{ext}' for ext in auxs])
+    cmd = f'rm {aux_files}'
+    subprocess.run(shlex.split(cmd))
+
+    print(f'Woohoo! I have successfully generated the file {diff_name}.pdf')
+    print("done!")

--- a/release/release.py
+++ b/release/release.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+'''
+Creates a new release
+
+from batch script:
+@echo off
+set hour=%time:~0,2%
+if "%hour:~0,1%" == " " set hour=0%hour:~1,1%
+set min=%time:~3,2%
+if "%min:~0,1%" == " " set min=0%min:~1,1%
+set secs=%time:~6,2%
+if "%secs:~0,1%" == " " set secs=0%secs:~1,1%
+
+set year=%date:~-4%
+set month=%date:~3,2%
+if "%month:~0,1%" == " " set month=0%month:~1,1%
+set day=%date:~0,2%
+if "%day:~0,1%" == " " set day=0%day:~1,1%
+
+set datetimef=%year%%month%%day%-%hour%%min%%secs%
+
+mkdir version%datetimef%
+cp *.pdf version%datetimef%/
+cp *.tex version%datetimef%/
+cp *.docx version%datetimef%/
+cp *.html version%datetimef%/
+cp *.md version%datetimef%/
+
+echo Woohoo! I have successfully generated the folder: version%datetimef%
+pause
+'''
+import glob
+import shlex
+import subprocess
+from datetime import datetime
+
+
+if __name__ == '__main__':
+    # folder name
+    folder = 'version' + datetime.today().strftime('%Y%m%d-%H%M%S')
+
+    # add here all file types to save as release
+    ftypes = [
+        '*.pdf',
+        '*.tex',
+        '*.docx',
+        '*.html',
+        '*.md',
+    ]
+
+    # grab all files
+    files = []
+    for ftype in ftypes:
+        files.extend(glob.glob(ftype))
+
+    # create folder
+    cmd = f'mkdir {folder}'
+    subprocess.run(shlex.split(cmd))
+
+    # copy all files to that folder
+    cmd = f"cp {' '.join(files)} {folder}"
+    subprocess.run(shlex.split(cmd))
+    
+    print(f'Woohoo! I have successfully generated the folder: {folder}')
+    print("done!")

--- a/release/templates/pandoc.tex
+++ b/release/templates/pandoc.tex
@@ -109,6 +109,14 @@ $for(bibliography)$
 \addbibresource{$bibliography$}
 $endfor$
 $endif$
+$if(csl-refs)$
+\newlength{\cslhangindent}
+\setlength{\cslhangindent}{1.5em}
+\newenvironment{cslreferences}%
+  {$if(csl-hanging-indent)$\setlength{\parindent}{0pt}%
+  \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces$endif$}%
+  {\par}
+$endif$
 $if(listings)$
 \usepackage{listings}
 $endif$

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,338 @@
+# -*- coding: utf-8 -*-
+'''
+Build script for Science.md
+
+Install Invoke using pip or pacman package manager, then run from cli:
+    jf@mymachine ~$ invoke all
+
+author: JF
+'''
+# standard library modules
+import os
+import shutil
+import tempfile
+
+# third party modules
+from invoke import task
+import regex as re
+from colorama import Fore, Back, init
+
+# initialize colorama
+init(autoreset=True)
+
+# set filename
+file_name = os.path.basename(os.path.abspath('.'))
+
+# set document content, watch out: order matters
+content = [
+    'title.md',
+    'abstract.md',
+    'introduction.md',
+    'methods.md',
+    'results.md',
+    'conclusion.md',
+    'appendix.md',
+    'acknowledgements.md',
+    'bib.md',
+]
+
+
+# emulate sed inplace edit using regular expresions
+def sed_i(re_a: str, re_b: str, file_name: str):
+    # create a temporary file to store data, as file can be big
+    with tempfile.TemporaryFile(mode='w+', encoding='utf-8') as tmp:
+        with open(file_name, 'r') as fi:
+            for line in fi:
+                tmp.write(re.sub(re_a, re_b, line, flags=re.VERSION1))
+        # rewind
+        tmp.seek(0)
+        # write output on the same file
+        with open(file_name, 'w') as fo:
+            fo.writelines(tmp.readlines())
+
+
+def wc_w(file_name: str) -> int:
+    ''' FROM HOWTO: \\S Matches any non-whitespace character;
+        this is equivalent to the class [^ \\t\\n\\r\\f\\v].
+        Not very accurate, but this gives the same result as wc -w
+    '''
+    # use iterator to avoid using a big list in case of large files
+    n_words = sum(1 for _ in re.finditer(r'\S+', open(file_name).read(), flags=re.VERSION1))
+    # n_words = len(re.findall(r'\S+', open(file_name).read()))
+    return n_words
+
+
+def human_readable(bsize: int) -> str:
+    """This function will convert bytes to MB.... GB... etc"""
+    for unit in ['bytes', 'KB', 'MB', 'GB', 'TB']:
+        if bsize < 1024:
+            bsize_str = f"{bsize:3.1f} {unit}"
+            break
+        bsize >>= 10
+    return bsize_str
+
+
+# emulate du -bh functionality
+def du_bh(file_name: str) -> str:
+    size = os.stat(file_name).st_size
+    return f'{human_readable(size)} {file_name}'
+
+
+def confirm(prompt='Confirm', res=False):
+    """Prompts confirmation from the user, returns True for yes.
+
+    The default value assumed when user types ENTER.
+    """
+    prompt = f'{prompt} [Y/n] ' if res else f'{prompt} [y/N] '
+
+    while True:
+        ans = input(prompt).lower()
+        if not ans:
+            return res
+        if ans not in ['y', 'yes', 'n', 'no']:
+            print('please enter y(es) or n(o)!')
+            continue
+        return (ans == 'y')
+
+
+def rm_i(file_name: str):
+    if confirm(f'Do you really want to delete {file_name}?'):
+        os.remove(file_name)
+
+
+@task
+def merge(c):
+    '''Meges all content file into one big file for later processing.'''
+
+    # create a text list with all content pages
+    # concatenate file contents, (it can be done with python later)
+    print(Fore.LIGHTMAGENTA_EX + f'cat content/*.md > release/{file_name}.md')
+    
+    # read content files from content folder and write it 
+    # into a one big file inside release folder
+    dst = os.path.join('release', f'{file_name}.md')
+    with open(dst, 'w') as fo:
+        for md_file in content:
+            src = os.path.join('content', md_file)
+            with open(src, 'r') as fi:
+                fo.writelines(fi.readlines())
+
+    # file space usage estimation
+    size = du_bh(f'release/{file_name}.md')
+    print(Fore.LIGHTGREEN_EX + f'> {size}')
+
+    # word count
+    n = wc_w(f'release/{file_name}.md')
+    print(f'i Less than {n} words')
+    # res = c.run(f'wc -w < release/{file_name}.md' , hide='both')
+    # print(f'i Less than {res.stdout.rstrip()} words')
+
+
+@task(merge)
+def tex(c):
+    '''From Markdown to LaTeX using pandoc'''
+
+    # create a temporary file
+    shutil.copyfile(f'release/{file_name}.md', f'release/{file_name}.temp.md')
+
+    # work on comments
+    print(Fore.LIGHTMAGENTA_EX + f'| sed s/==XX comment==/*\\XX comment*/ release/{file_name}.md')
+
+    # First change TODO tags
+    sed_i(r'==TODO==', r'\\TODO', f'release/{file_name}.temp.md')
+    # Then change all other tags
+    sed_i(r'==([a-zA-Z]+) ([^=]+)==', r'*\\\1 \2*', f'release/{file_name}.temp.md')
+
+    # change extension to .pdf in image strings
+    print(Fore.LIGHTMAGENTA_EX + f'| sed s/.png/.pdf/ release/{file_name}.md')
+    sed_i(r'.png', r'.pdf', f'release/{file_name}.temp.md')
+
+    # pandoc options, modify parameters here!
+    pandoc_opts = [
+        '--wrap=preserve',
+        '-s',
+        '--filter pandoc-crossref',
+        '--filter=pandoc-citeproc',
+        '-f markdown',
+        '-V colorlinks',
+        '-V papersize=a4',
+        '-V geometry=margin=1in',
+        '--number-sections',
+        '-M secPrefix=section',
+        '-M tblPrefix=Table',
+        '--template templates/pandoc.tex',
+    ]
+    # run pandoc
+    print(Fore.LIGHTMAGENTA_EX + f'| pandoc release/{file_name}.md -o release/{file_name}.tex')
+    os.chdir('release')
+    c.run(f'pandoc {" ".join(pandoc_opts)} {file_name}.temp.md -o {file_name}.tex')
+    os.chdir('..')
+
+    # file space usage estimation
+    size = du_bh(f'release/{file_name}.tex')
+    print(Fore.LIGHTGREEN_EX + f'> {size}')
+
+    # delete auxiliary files
+    os.remove(f'release/{file_name}.temp.md')
+
+
+@task(merge)
+def pdf(c):
+    '''From Markdown to PDF using pandoc'''
+
+    # create a temporary file
+    shutil.copyfile(f'release/{file_name}.md', f'release/{file_name}.temp.md')
+
+    # work on comments
+    print(Fore.LIGHTMAGENTA_EX + f'| sed s/==XX comment==/*\\XX comment*/ release/{file_name}.md')
+
+    # First change TODO tags
+    sed_i(r'==TODO==', r'\\TODO', f'release/{file_name}.temp.md')
+    # Then change all other tags
+    sed_i(r'==([a-zA-Z]+) ([^=]+)==', r'*\\\1 \2*', f'release/{file_name}.temp.md')
+
+    # change extension to .pdf in image strings
+    print(Fore.LIGHTMAGENTA_EX + f'| sed s/.png/.pdf/ release/{file_name}.md')
+    sed_i(r'.png', r'.pdf', f'release/{file_name}.temp.md')
+
+    # pandoc options, modify parameters here!
+    pandoc_opts = [
+        '--wrap=preserve',
+        '-s',
+        '--filter pandoc-crossref',
+        '--filter=pandoc-citeproc',
+        '-f markdown',
+        '-V colorlinks',
+        '-V papersize=a4',
+        '-V geometry=margin=1in',
+        '--number-sections',
+        '-M secPrefix=section',
+        '-M tblPrefix=Table',
+        '--template templates/pandoc.tex',
+        '--csl templates/copernicus.csl',
+    ]
+    # run pandoc
+    print(Fore.LIGHTMAGENTA_EX + f'| pandoc release/{file_name}.md -o release/{file_name}.pdf')
+    os.chdir('release')
+    c.run(f'pandoc {" ".join(pandoc_opts)} {file_name}.temp.md -o {file_name}.pdf')
+    os.chdir('..')
+
+    # file space usage estimation
+    size = du_bh(f'release/{file_name}.pdf')
+    print(Fore.LIGHTGREEN_EX + f'> {size}')
+
+    # delete auxiliary files
+    os.remove(f'release/{file_name}.temp.md')
+
+
+@task(merge)
+def docx(c):
+    '''From Markdown to Word using pandoc'''
+
+    # create a temporary file
+    shutil.copyfile(f'release/{file_name}.md', f'release/{file_name}.temp.md')
+
+    # work on comments
+    print(Fore.LIGHTMAGENTA_EX + f'| sed s/==XX comment==/*\\XX comment*/ release/{file_name}.md')
+
+    # First change TODO tags
+    sed_i(r'==TODO==', r'<span custom-style="TODO"> TODO </span>', f'release/{file_name}.temp.md')
+
+    # Then change all other tags
+    sed_i(
+        r'==([a-zA-Z]+) ([^=]+)==',
+        r'<span custom-style="comment-name"> \1 </span><span custom-style="comment"> \2</span>',
+        f'release/{file_name}.temp.md'
+    )
+
+    # pandoc options, modify parameters here!
+    pandoc_opts = [
+        '--wrap=preserve',
+        '-s',
+        '--filter pandoc-crossref',
+        '--filter=pandoc-citeproc',
+        '-f markdown',
+        '--number-sections',
+        '-M secPrefix=section',
+        '-M numberSections=true',
+        '-M tblPrefix=Table',
+        '--reference-doc=templates/reference.docx',
+    ]
+    # run pandoc
+    print(Fore.LIGHTMAGENTA_EX + f'| pandoc release/{file_name}.md -o release/{file_name}.docx')
+
+    os.chdir('release')
+    c.run(f'pandoc {" ".join(pandoc_opts)} {file_name}.temp.md -o {file_name}.docx')
+    os.chdir('..')
+
+    # file space usage estimation
+    size = du_bh(f'release/{file_name}.docx')
+    print(Fore.LIGHTGREEN_EX + f'> {size}')
+
+    # delete auxiliary files
+    os.remove(f'release/{file_name}.temp.md')
+
+
+@task(merge)
+def html(c):
+    '''From Markdown to HTML using pandoc'''
+
+    # create temporary file
+    shutil.copyfile(f'release/{file_name}.md', f'release/{file_name}.temp.md')
+
+    # change comment strings
+    print(Fore.LIGHTMAGENTA_EX + f'| sed s/==XX comment==/[XX] comment/ release/{file_name}.md')
+    # First change TODO tags
+    sed_i(r'==TODO==', r'<span class="todo">TODO</span>', f'release/{file_name}.temp.md')
+    # Then change all other tags
+    sed_i(
+        r'==([a-zA-Z]+) ([^=]+)==',
+        r'<span class="comment \1"><b>\1</b> \2</span>',
+        f'release/{file_name}.temp.md'
+    )
+
+    # pandoc options, modify parameters here!
+    pandoc_opts = [
+        '--wrap=preserve',
+        '-s',
+        '--filter pandoc-crossref',
+        '--filter pandoc-citeproc',
+        '-f markdown',
+        '--template templates/pandoc.html',
+        '-t html5',
+        '--mathjax',
+        '--number-sections',
+        '-M secPrefix=section',
+        '-M tblPrefix=Table',
+    ]
+    # run pandoc
+    print(Fore.LIGHTMAGENTA_EX + f'| pandoc release/{file_name}.md -o release/{file_name}.html')
+    os.chdir('release')
+    c.run(f'pandoc {" ".join(pandoc_opts)} {file_name}.temp.md -o {file_name}.html')
+    os.chdir('..')
+
+    # file space usage estimation
+    size = du_bh(f'release/{file_name}.html')
+    print(Fore.LIGHTGREEN_EX + f'> {size}')
+
+    # delete auxiliary files
+    os.remove(f'release/{file_name}.temp.md')
+
+
+@task(pre=[merge, html, docx, tex, pdf])
+def all(c):
+    '''From Markdown to Everything'''
+    pass
+
+
+@task
+def clean(c):
+    '''Clean `release/` folder from garbage. Remove `-i` flag if you know what you do.'''
+    os.chdir('release')
+    with os.scandir('.') as it:
+        for entry in it:
+            if not entry.name.startswith('.') and entry.is_file():
+                if entry.name.startswith(file_name):
+                    rm_i(entry.name)
+    os.chdir('..')
+    # c.run(f'rm -i release/{file_name}.*')


### PR DESCRIPTION
Hey I commented yesterday about an issue you had, looking for help for translating .bat files to linux. I made a python script for each .bat file, in linux they will work (python 3.7+) and you can test if they work in windows (maybe pdf2png.py not because the trailing .exe in mutool, but we can figure out a solution later).